### PR TITLE
Link Tag ID to Checkbox programmatically

### DIFF
--- a/L.Control.Layers.Tree.js
+++ b/L.Control.Layers.Tree.js
@@ -357,11 +357,12 @@
                 // now create the element like in _addItem
                 var checked = this._map.hasLayer(tree.layer)
                 var input;
+                var id = tree.id;
                 var radioGroup = overlay ? tree.radioGroup : 'leaflet-base-layers_' + L.Util.stamp(this);
                 if (radioGroup) {
                     input = this._createRadioElement(radioGroup, checked);
                 } else {
-                    input = this._createCheckboxElement(checked);
+                    input = this._createCheckboxElement(checked, id);
                 }
                 if (this._layerControlInputs) {
                     // to keep compatibility with 1.0.3
@@ -372,6 +373,7 @@
                 label.appendChild(input);
             }
             var name = creator('span', this.cls.name, label, tree.label);
+
             L.DomUtil.addClass(closed, hide);
             if (noShow) {
                 L.DomUtil.addClass(header, this.cls.neverShow);
@@ -379,8 +381,9 @@
             }
         },
 
-        _createCheckboxElement: function(checked) {
+        _createCheckboxElement: function (checked, id) {
             var input = document.createElement('input');
+            if (id) { input.id = id };
             input.type = 'checkbox';
             input.className = 'leaflet-control-layers-selector';
             input.defaultChecked = checked;


### PR DESCRIPTION
In my project's scope, I had to set an event listener to the checkbox to link the action of 'checking' it to another Component. The only way I found was to link its tag ID during the process of creation. 
Hope it should help.

It gives the opportunity to assign an additional event to this 'checked' event because of the retrieving of its own Tag ID

[ Possibility to link this to the _createRadioElement method too ]