### PR TITLE
Add option to select if a label should be clickable to toggle layer.

### DIFF
--- a/L.Control.Layers.Tree.js
+++ b/L.Control.Layers.Tree.js
@@ -21,6 +21,7 @@
             namedToggle: false,
             collapseAll: '',
             expandAll: '',
+            labelIsSelector: 'both',
         },
 
         // Class names are error prone texts, so write them once here
@@ -351,8 +352,21 @@
                 L.DomUtil.addClass(sel, this.cls.neverShow);
             }
 
-            // create the input and label, as in Control.Layers
-            var label = creator(tree.layer ? 'label' : 'span', this.cls.label, entry);
+            // make (or not) the label clickable to toggle the layer
+            var labelType;
+            if (tree.layer) {
+                if ((this.options.labelIsSelector === 'both') || // if option is set to both
+                    (overlay && this.options.labelIsSelector === 'overlay') || // if an overlay layer and options is set to overlay
+                    (!overlay && this.options.labelIsSelector === 'base')) { // if a base layer and option is set to base
+                    labelType = 'label'
+                } else { // if option is set to something else
+                    labelType = 'span'
+                }
+            } else {
+                labelType = 'span';
+            }
+            // create the input and label
+            var label = creator(labelType, this.cls.label, entry);
             if (tree.layer) {
                 // now create the element like in _addItem
                 var checked = this._map.hasLayer(tree.layer)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Creates the control. The arguments are:
 * `namedToggle`: `<Boolean>` Flag to replace the toggle image (box with the layers image) with the 'name' of the selected base layer. If the `name` field is not present in the tree for this layer, `label` is used. See that you can show a different name when control is collapsed than the one that appears in the tree when it is expanded. Your node in the tree can be `{ label: 'OSM', name: 'OpenStreetMap', layer: layer }`. Default 'false'.
 * `collapseAll`: `<String>` Text for an entry in control that collapses the tree (baselayers or overlays). If empty, no entry is created. Default ''.
 * `expandAll`: `<String>` Text for an entry in control that expands the tree. If empty, no entry is created. Default ''.
+* `labelIsSelector`: `<String>` Controls if a label or only the checkbox/radiobutton can toggle layers. If set to both, overlay or base those labels can be clicked on to toggle the layer. Default 'both'.
 
 See that those strings can be html code, with unicode, images or whatever you want.
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -85,7 +85,7 @@ function checkHidden(list, value, first) {
 }
 
 describe('L.Control.Layers.Tree', function() {
-    chai.should();
+    var should = chai.should();
     this.timeout(5000);
     var map;
 
@@ -261,6 +261,42 @@ describe('L.Control.Layers.Tree', function() {
             map._layers[L.Util.stamp(layerB)].should.be.equal(layerB);
             happen.click(headers[4].querySelector('label'));
             map._layers[L.Util.stamp(layerA)].should.be.equal(layerA);
+        });
+
+        it('labelIsSelector', function() {
+            var ctl;
+            var counter = [0, 0, 0, 0];
+            ['both', 'base', 'overlay', 'none'].forEach(function(labelIsSelector) {
+                ctl && map.removeControl(ctl);
+                ctl = L.control.layers.tree(baseTree1(), overlaysArray1(), {collapsed: false, labelIsSelector: labelIsSelector}).addTo(map);
+                var headers = map._container.querySelectorAll('.leaflet-layerstree-header');
+                headers.length.should.be.equal(14);
+
+                if (labelIsSelector === 'both' || labelIsSelector === 'base') {
+                    happen.click(headers[6].querySelector('label'));
+                    map._layers[L.Util.stamp(layerB)].should.be.equal(layerB);
+                    counter[0]++;
+                } else {
+                    should.not.exist(headers[6].querySelector('label'));
+                    happen.click(headers[6].querySelector('input'));
+                    map._layers[L.Util.stamp(layerB)].should.be.equal(layerB);
+                    counter[1]++;
+                }
+
+                if (labelIsSelector === 'both' || labelIsSelector === 'overlay') {
+                    happen.click(headers[11].querySelector('label'));
+                    map._layers[L.Util.stamp(markerA)].should.be.equal(markerA);
+                    counter[2]++;
+                } else {
+                    should.not.exist(headers[11].querySelector('label'));
+                    happen.click(headers[11].querySelector('input'));
+                    map._layers[L.Util.stamp(markerA)].should.be.equal(markerA);
+                    counter[3]++;
+                }
+                map.removeLayer(layerB);
+                map.removeLayer(markerA);
+            });
+            chai.expect(counter).to.eql([2, 2, 2, 2]);
         });
     });
 


### PR DESCRIPTION
A click on a layer label or name toggles the visibility of the layer in the map. With this pull request, there is an extra option to disable this. Then only a click on the checkbox/radio button toggles the layers.