### PR TITLE
Prevent click propagation and collapsing tree on mobile browsers

### DIFF
--- a/L.Control.Layers.Tree.js
+++ b/L.Control.Layers.Tree.js
@@ -369,6 +369,10 @@
                 L.DomUtil.addClass(sensible, this.cls.pointer);
                 sensible.tabIndex = 0;
                 L.DomEvent.on(sensible, 'click keydown', function(e) {
+                    // leaflet internal flag to prevent click propagation and collapsing tree on mobile browsers
+                    if (this._preventClick) {
+                        return;
+                    }
                     if (e.type === 'keydown' && e.keyCode !== 32) {
                         return
                     }


### PR DESCRIPTION
Uses the same solution as Leaflet to fix click propagation on mbile browsers.
https://github.com/Leaflet/Leaflet/issues/8778, https://github.com/Leaflet/Leaflet/pull/8910

Fixes: #67

@PedroVenancio, @jjimenezshaw